### PR TITLE
Bump activesupport: gem is now called "activesupport"

### DIFF
--- a/hash_mapper.gemspec
+++ b/hash_mapper.gemspec
@@ -47,12 +47,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<active_support>, [">= 3.0.0.beta"])
+      s.add_runtime_dependency("activesupport", "~> 3.0")
     else
-      s.add_dependency(%q<active_support>, [">= 3.0.0.beta"])
+      s.add_dependency("activesupport", "~> 3.0")
     end
   else
-    s.add_dependency(%q<active_support>, [">= 3.0.0.beta"])
+    s.add_dependency("activesupport", "~> 3.0")
   end
 end
 


### PR DESCRIPTION
I've tweaked the activesupport dependency so hash_mapper is compatible with 3.0.x.
Cheers,
Dave
