### PR TITLE
Use symbol to access hash values

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Do this:
 
 ```ruby
 map from('/names'), to('/user') do |names|
-  "Mr. #{names[1]}, #{names[0]}"
+  "Mr. #{names[:last]}, #{names[:first]}"
 end
 ```
 


### PR DESCRIPTION
Hi!

A couple of days ago I was trying out the gem and I've noticed a problem with the documentation about Custom value filtering. 

The object yielded to the block seems to be an array, indeed in the doc you access the values by index. But in fact it is a hash, and you have to use the original keys to access the values.

What do you think? Anything else I should do?

Thank you
