### PR TITLE
Add support for multiple filters of the same type

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ end
 Important: note that for before filters, you need to return the (modified) input, and for after filters, you need to return the output.
 Note also that 'output' is correct at the time of the filter, i.e. before_normalize yields 'output' as an empty hash, while after_normalize yields it as an already normalized hash.
 
+It is possible to define multiple filters of a given type. These are run in the order in which they are defined. A common use case might be to define a `before_normalize` filter in a parent class and a child class. The output from the previous invocation of the filter is passed as the input of the next invocation.
+
    
 ## REQUIREMENTS:
 


### PR DESCRIPTION
Support for multiple `(before|after)_(normalize|denormalize)` filters, including across different classes in a class hierarchy.

Filters are run in the order in which they are defined.

For example:

```ruby
class MultiBeforeFilter
  extend HashMapper

  before_normalize do |input, output|
    input[:foo] << 'Y'
    input
  end

  before_normalize do |input, output|
    input[:foo] << 'Z'
    input
  end

  map from('/foo'), to('bar')
end

class MultiBeforeFilterSubclass < MultiBeforeFilter
  before_normalize do |input, output|
    input[:foo] << '!'
    input
  end
end

MultiBeforeFilterSubclass.normalize({ foo: 'X' }) # => { bar: 'XYZ!' }
```