### PR TITLE
Adds the possibility to give extra argument to before and after filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,26 @@ Note also that 'output' is correct at the time of the filter, i.e. before_normal
 
 It is possible to define multiple filters of a given type. These are run in the order in which they are defined. A common use case might be to define a `before_normalize` filter in a parent class and a child class. The output from the previous invocation of the filter is passed as the input of the next invocation.
 
+You can pass one extra argument to before and after filters if you need to:
+```ruby
+class EggMapper
+  map from('/raw'), to('/fried')
+  
+  before_normalize do |input, output, opts|
+    input['raw'] ||= 'please' unless opts[:no_default] # this will give 'raw' a default value 
+    input
+  end
+  
+  after_denormalize do |input, output, opts|
+    output.to_a        # the denormalized object will now be an array, not a hash!!
+  end
+
+end
+
+EggMapper.normalize({}, no_default: true)
+EggMapper.denormalize({fried: 4})
+```
+
    
 ## REQUIREMENTS:
 

--- a/lib/hash_mapper.rb
+++ b/lib/hash_mapper.rb
@@ -73,12 +73,12 @@ module HashMapper
     { using: mapper_class }
   end
 
-  def normalize(a_hash)
-    perform_hash_mapping a_hash, :normalize
+  def normalize(a_hash, opts = {})
+    perform_hash_mapping a_hash, :normalize, opts
   end
 
-  def denormalize(a_hash)
-    perform_hash_mapping a_hash, :denormalize
+  def denormalize(a_hash, opts = {})
+    perform_hash_mapping a_hash, :denormalize, opts
   end
 
   def before_normalize(&blk)
@@ -99,12 +99,12 @@ module HashMapper
 
   protected
 
-  def perform_hash_mapping(a_hash, meth)
+  def perform_hash_mapping(a_hash, meth, opts)
     output = {}
 
     # Before filters
     a_hash = self.send(:"before_#{meth}_filters").inject(a_hash) do |memo, filter|
-      filter.call(memo, output)
+      filter.call(memo, output, opts)
     end
 
     # Do the mapping
@@ -114,7 +114,7 @@ module HashMapper
 
     # After filters
     self.send(:"after_#{meth}_filters").inject(output) do |memo, filter|
-      filter.call(a_hash, memo)
+      filter.call(a_hash, memo, opts)
     end
   end
 

--- a/spec/hash_mapper_spec.rb
+++ b/spec/hash_mapper_spec.rb
@@ -563,3 +563,43 @@ describe 'multiple after filters' do
     end
   end
 end
+
+class WithOptions
+  extend HashMapper
+
+  before_normalize do |input, output, opts|
+    output[:bn] = opts[:bn] if opts[:bn]
+    input
+  end
+
+  after_normalize do |input, output, opts|
+    output[:an] = opts[:an] if opts[:an]
+    output
+  end
+
+  before_denormalize do |input, output, opts|
+    output[:bdn] = opts[:bdn] if opts[:bdn]
+    input
+  end
+
+  after_denormalize do |input, output, opts|
+    output[:adn] = opts[:adn] if opts[:adn]
+    output
+  end
+end
+
+describe 'with options' do
+  context 'when called with options' do
+    it 'passes the options to all the filters' do
+      WithOptions.normalize({}, bn: 1, an: 2).should == {bn: 1, an: 2}
+      WithOptions.denormalize({}, bdn: 1, adn: 2).should == {bdn: 1, adn: 2}
+    end
+  end
+
+  context 'when called without options' do
+    it 'stills work' do
+      WithOptions.normalize({}).should == {}
+      WithOptions.denormalize({}).should == {}
+    end
+  end
+end


### PR DESCRIPTION
Add the possibility to give options to normalize and denormalize that will be passed to the before and after filters:

Example:
```ruby
class EggMapper
  map from('/raw'), to('/fried')
  
  before_normalize do |input, output, opts|
    input['raw'] ||= 'please' unless opts[:no_default] # this will give 'raw' a default value 
    input
  end
  
  after_denormalize do |input, output, opts|
    output.to_a        # the denormalized object will now be an array, not a hash!!
  end

end

EggMapper.normalize({}, no_default: true)
EggMapper.denormalize({fried: 4})
```