### PR TITLE
Added support for activesupport/rails 5

### DIFF
--- a/hash_mapper.gemspec
+++ b/hash_mapper.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   
   if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-    s.add_runtime_dependency("activesupport", "~> 4")
+    s.add_runtime_dependency("activesupport", ">= 4")
   else
-    s.add_dependency("activesupport", "~> 4")
+    s.add_dependency("activesupport", ">= 4")
   end
   
   # specify any dependencies here; for example:


### PR DESCRIPTION
Right now with activesupport 5, bundler will only allow access to hash_mapper 0.9. I've changed it so that it will accept any version of activesupport 4 or higher.