### PR TITLE
Removed the date from gemfile

### DIFF
--- a/hash_mapper.gemspec
+++ b/hash_mapper.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.version     = HashMapper::VERSION
   s.authors     = ['Ismael Celis']
   s.description = %q{Tiny module that allows you to easily adapt from one hash structure to another with a simple declarative DSL.}
-  s.date        = %q{2010-09-21}
   s.email       = %q{ismaelct@gmail.com}
   
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Right now (according to rubygems.org) every release of hash_mapper was released on the same date. This seems to be because it's taking the date from the gemspec. I've removed that, so hopefully now the release date should be the same as the date it was published to rubygems.org

Here's what I see on rubygems.org

<img width="355" alt="screen shot 2016-09-09 at 17 26 21" src="https://cloud.githubusercontent.com/assets/111963/18394638/c426deb6-76b2-11e6-90e7-c5e55f85079f.png">

https://rubygems.org/gems/hash_mapper/versions