### PR TITLE
Run context

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ class EggMapper
 
 end
 
-EggMapper.normalize({}, no_default: true)
+EggMapper.normalize({}, options: { no_default: true })
 EggMapper.denormalize({fried: 4})
 ```
 

--- a/lib/hash_mapper.rb
+++ b/lib/hash_mapper.rb
@@ -39,6 +39,7 @@ unless [].respond_to?(:inject_with_index)
 end
 
 module HashMapper
+  DEFAULT_OPTIONS = {}.freeze
 
   def self.extended(base)
     base.class_eval do
@@ -73,11 +74,11 @@ module HashMapper
     { using: mapper_class }
   end
 
-  def normalize(a_hash, options: {})
+  def normalize(a_hash, options: DEFAULT_OPTIONS)
     perform_hash_mapping a_hash, :normalize, options
   end
 
-  def denormalize(a_hash, options: {})
+  def denormalize(a_hash, options: DEFAULT_OPTIONS)
     perform_hash_mapping a_hash, :denormalize, options
   end
 

--- a/lib/hash_mapper.rb
+++ b/lib/hash_mapper.rb
@@ -74,12 +74,12 @@ module HashMapper
     { using: mapper_class }
   end
 
-  def normalize(a_hash, options: DEFAULT_OPTIONS)
-    perform_hash_mapping a_hash, :normalize, options
+  def normalize(a_hash, options: DEFAULT_OPTIONS, context: nil)
+    perform_hash_mapping a_hash, :normalize, options: options
   end
 
-  def denormalize(a_hash, options: DEFAULT_OPTIONS)
-    perform_hash_mapping a_hash, :denormalize, options
+  def denormalize(a_hash, options: DEFAULT_OPTIONS, context: nil)
+    perform_hash_mapping a_hash, :denormalize, options: options
   end
 
   def before_normalize(&blk)
@@ -100,12 +100,12 @@ module HashMapper
 
   protected
 
-  def perform_hash_mapping(a_hash, meth, opts)
+  def perform_hash_mapping(a_hash, meth, options:)
     output = {}
 
     # Before filters
     a_hash = self.send(:"before_#{meth}_filters").inject(a_hash) do |memo, filter|
-      filter.call(memo, output, opts)
+      filter.call(memo, output, options)
     end
 
     # Do the mapping
@@ -115,7 +115,7 @@ module HashMapper
 
     # After filters
     self.send(:"after_#{meth}_filters").inject(output) do |memo, filter|
-      filter.call(a_hash, memo, opts)
+      filter.call(a_hash, memo, options)
     end
   end
 

--- a/lib/hash_mapper.rb
+++ b/lib/hash_mapper.rb
@@ -73,12 +73,12 @@ module HashMapper
     { using: mapper_class }
   end
 
-  def normalize(a_hash, opts = {})
-    perform_hash_mapping a_hash, :normalize, opts
+  def normalize(a_hash, options: {})
+    perform_hash_mapping a_hash, :normalize, options
   end
 
-  def denormalize(a_hash, opts = {})
-    perform_hash_mapping a_hash, :denormalize, opts
+  def denormalize(a_hash, options: {})
+    perform_hash_mapping a_hash, :denormalize, options
   end
 
   def before_normalize(&blk)

--- a/spec/hash_mapper_spec.rb
+++ b/spec/hash_mapper_spec.rb
@@ -601,3 +601,30 @@ describe 'with options' do
     end
   end
 end
+
+describe 'passing custom context object' do
+  it 'passes context object down to sub-mappers' do
+    friend_mapper = Class.new do
+      extend HashMapper
+
+      map from('/name'), to('/name')
+
+      def normalize(input, context: , **kargs)
+        context[:names] ||= []
+        context[:names] << input[:name]
+        self.class.normalize(input, context: context, **kargs)
+      end
+    end
+
+    mapper = Class.new do
+      extend HashMapper
+
+      map from('/friends'), to('/friends'), using: friend_mapper.new
+    end
+
+    input = {friends: [{name: 'Ismael', last_name: 'Celis'}, {name: 'Joe'}]}
+    ctx = {}
+    mapper.normalize(input, context: ctx)
+    expect(ctx[:names]).to eq(%w(Ismael Joe))
+  end
+end

--- a/spec/hash_mapper_spec.rb
+++ b/spec/hash_mapper_spec.rb
@@ -589,8 +589,8 @@ end
 describe 'with options' do
   context 'when called with options' do
     it 'passes the options to all the filters' do
-      expect(WithOptions.normalize({}, bn: 1, an: 2)).to eq({bn: 1, an: 2})
-      expect(WithOptions.denormalize({}, bdn: 1, adn: 2)).to eq({bdn: 1, adn: 2})
+      expect(WithOptions.normalize({}, options: { bn: 1, an: 2 })).to eq({bn: 1, an: 2})
+      expect(WithOptions.denormalize({}, options: { bdn: 1, adn: 2 })).to eq({bdn: 1, adn: 2})
     end
   end
 


### PR DESCRIPTION
Pass optional _context_ object to all sub-mappers

```ruby
# context will be passed down to all sub mappers in the tree
output = SomeMapper.normalize(input, context: {})
```

