### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on: push
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - '2.6'
+          - '2.7'
+    name: Ruby ${{ matrix.ruby }} RSpec
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+    - run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[ ![Codeship Status for ismasan/hash_mapper](https://www.codeship.io/projects/85d172c0-4668-0132-e925-7a7d3d72b19b/status)](https://www.codeship.io/projects/45296)
+[![GitHub Actions status](https://github.com/ismasan/hash_mapper/workflows/Tests/badge.svg)](https://github.com/ismasan/hash_mapper)
 
 # hash_mapper
 


### PR DESCRIPTION
I've only added Ruby 2.6 and 2.7 for now because [2.5 will soon be EOL](https://www.ruby-lang.org/en/downloads/) and there are a few failing tests on 3 (that I don't want to fix in this PR). You can [see the tests passing on my branch](https://github.com/benpickles/hash_mapper/actions/runs/509713276).

I also replaced the CodeShip status badge in the README - though this doesn't render as it's pointing to ismasan/hash_mapper where it doesn't yet exist ([here's the badge referencing my repo](https://github.com/benpickles/hash_mapper/workflows/Tests/badge.svg)).

Closes #16.