### PR TITLE
Callable filters

### DIFF
--- a/lib/hash_mapper.rb
+++ b/lib/hash_mapper.rb
@@ -59,15 +59,17 @@ module HashMapper
     end
   end
 
-  def map(from, to, options={}, &filter)
+  def map(from, to, options={}, &block_filter)
+    filter = options.delete(:filter) || block_filter
     self.maps = self.maps.dup
     self.maps << Map.new(from, to, options)
-    to.filter = filter if block_given? # Useful if just one block given
+    to.filter = filter if filter # Useful if just one block given
   end
 
-  def from(path, &filter)
+  def from(path, filter: nil, &block_filter)
     path_map = PathMap.new(path)
-    path_map.filter = filter if block_given? # Useful if two blocks given
+    filter ||= block_filter if block_given?
+    path_map.filter = filter if filter # Useful if two blocks given
     path_map
   end
 

--- a/spec/hash_mapper_spec.rb
+++ b/spec/hash_mapper_spec.rb
@@ -187,7 +187,20 @@ describe "with block filters" do
   it "should accept a block for just one direction" do
     expect(PersonWithBlockOneWay.normalize(@from)).to eq(@to)
   end
+end
 
+describe ':filter' do
+  let(:mapper) do
+    Class.new do
+      extend HashMapper
+      map from('/names/first'), to('/first_name', filter: ->(s) { s.strip })
+    end
+  end
+
+  it 'registers filters as callables, too' do
+    output = mapper.normalize({ names: { first: ' Joe Bloggs  ' }})
+    expect(output[:first_name]).to eq('Joe Bloggs')
+  end
 end
 
 class ProjectMapper

--- a/spec/hash_mapper_spec.rb
+++ b/spec/hash_mapper_spec.rb
@@ -647,7 +647,7 @@ describe 'passing context down to filters' do
     mapper = Class.new do
       extend HashMapper
 
-      map from('/name'), to('/name', &(->(name, ctx) { "#{ctx[:title]} #{name}" }))
+      map from('/name'), to('/name', filter: ->(name, ctx) { "#{ctx[:title]} #{name}" })
       map from('/age'), to('/age') do |age, ctx|
         "#{age} #{ctx[:age_suffix]}"
       end


### PR DESCRIPTION
Allow passing callables as per-field mapping filters

```ruby
name_with_title = ->(name) { "Mr. #{name}" } # or anything that responds to `#call(value)`.
map from('/name'), to('/name', filter: name_with_title )
```