### PR TITLE
Also test against Ruby 3.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ jobs:
         ruby:
           - '2.6'
           - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
     name: Ruby ${{ matrix.ruby }} RSpec
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .bundle
 Gemfile.lock
 pkg/*
+/spec/examples.txt
 .idea
 .rvmrc

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/lib/hash_mapper.rb
+++ b/lib/hash_mapper.rb
@@ -2,9 +2,6 @@
 
 require 'hash_mapper/version'
 
-$:.unshift(File.dirname(__FILE__)) unless
-$:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
-
 def require_active_support
   require 'active_support/core_ext/array/extract_options'
   require 'active_support/core_ext/hash/indifferent_access'

--- a/spec/hash_mapper_spec.rb
+++ b/spec/hash_mapper_spec.rb
@@ -154,7 +154,7 @@ end
 
 class PersonWithBlock
   extend HashMapper
-  def self.normalize(*_)
+  def self.normalize(*_, **_)
     super
   end
   map from('/names/first'){|n| n.gsub('+','')}, to('/first_name'){|n| "+++#{n}+++"}

--- a/spec/hash_mapper_spec.rb
+++ b/spec/hash_mapper_spec.rb
@@ -394,7 +394,7 @@ describe "inherited mappers" do
   end
 
   it "should not affect other mappers" do
-    expect(NotRelated.normalize('n' => 'nn')).to eq({n: {n: 'nn'}})
+    expect(NotRelated.normalize({ 'n' => 'nn' })).to eq({n: {n: 'nn'}})
   end
 end
 
@@ -407,17 +407,17 @@ end
 describe "dealing with strings and symbols" do
 
   it "should be able to normalize from a nested hash with string keys" do
-    expect(MixedMappings.normalize(
+    expect(MixedMappings.normalize({
       'big' => {'jobs' => 5},
       'timble' => 3.2
-    )).to eq({dodo: 5, bingo: {biscuit: 3.2}})
+    })).to eq({dodo: 5, bingo: {biscuit: 3.2}})
   end
 
   it "should not symbolized keys in value hashes" do
-    expect(MixedMappings.normalize(
+    expect(MixedMappings.normalize({
       'big' => {'jobs' => 5},
       'timble' => {'string key' => 'value'}
-    )).to eq({dodo: 5, bingo: {biscuit: {'string key' => 'value'}}})
+    })).to eq({dodo: 5, bingo: {biscuit: {'string key' => 'value'}}})
   end
 
 end
@@ -431,9 +431,9 @@ end
 
 describe "default values" do
   it "should use a default value whenever a key is not set" do
-    expect(DefaultValues.normalize(
+    expect(DefaultValues.normalize({
       'without_default' => 'some_value'
-    )).to eq({ not_defaulted: 'some_value', defaulted: 'the_default_value' })
+    })).to eq({ not_defaulted: 'some_value', defaulted: 'the_default_value' })
   end
 
   it "should not use a default if a key is set (even if the value is falsy)" do

--- a/spec/hash_mapper_spec.rb
+++ b/spec/hash_mapper_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper.rb'
-
 class OneLevel
   extend HashMapper
   map from('/name'),            to('/nombre')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,5 +18,4 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 end
 
-$:.unshift(File.dirname(__FILE__) + '/../lib')
 require 'hash_mapper'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.example_status_persistence_file_path = "spec/examples.txt"
 end
 
 $:.unshift(File.dirname(__FILE__) + '/../lib')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@ RSpec.configure do |config|
   end
 
   config.example_status_persistence_file_path = "spec/examples.txt"
+
+  config.order = :random
+  Kernel.srand config.seed
 end
 
 $:.unshift(File.dirname(__FILE__) + '/../lib')


### PR DESCRIPTION
HashMapper was already compatible with Ruby 3.x but the tests required a few tweaks.

I also removed the load path manipulation which was presumably required back in the day but isn't required now.